### PR TITLE
Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
     - "tar -xzvf nltk_data.tar.gz -C ~"
 
 install:
+  - pip install -r requirements-tests.txt
   - pip install -U .
 
 script: python run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,19 @@
 language: python
 
 python:
-  - "3.7"
+  - "3.6"
+  - "3.5"
   - "3.4"
   - "3.3"
   - "2.7"
-  - "2.6"
   - "pypy"
+
+# Enable Python 3.7. Requires OpenSSL 1.0.2+ which is not available for Trusty
+matrix:
+  include:
+  - python: 3.7
+    dist: xenial
+    sudo: true
 
 before_install:
     - "wget https://s3.amazonaws.com/textblob/nltk_data.tar.gz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 language: python
 
 python:
+  - "3.7"
   - "3.4"
   - "3.3"
   - "2.7"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -36,7 +36,7 @@ Setting Up for Local Development
     $ virtualenv tb-de
     $ <activate virtual environment>
 
-3. Install development requirements and run ``setupy.py develop``.
+3. Install development requirements and run ``setup.py develop``.
    (see `Makefile help <project_makefile.html>`_ for overview of available 
    ``make`` targets)::
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,7 @@
+setuptools==39.2.0
 pep8==1.5.7
 autopep8
-flake
+flake8
 nose>=1.3.0
 pytest
 tox>=1.5.0

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -291,7 +291,9 @@ class SentenceTest(TestCase):
         # it does not (not entirely sure if this is Google or TextBlob)
         # Further tests needed.
         assert_true(translated in ["This is a sentence.",
-                                   "This is a sentence ."])
+                                   "This is a sentence .",
+                                   "That's a sentence.",
+                                   "That's a sentence ."])
 
     @expected_failure
     def test_correct(self):
@@ -310,6 +312,7 @@ class SentenceTest(TestCase):
     def test_translate_detects_language_by_default(self):
         blob = tb.TextBlobDE(unicode("ذات سيادة كاملة"))
         assert_true(blob.translate() in ("Vollständig souveränen",
+                                         "Völlig souverän",
                                          "Mit voller Souveränität",
                                          "Mit vollen Souveränität"))
 

--- a/textblob_de/ext/_pattern/text/__init__.py
+++ b/textblob_de/ext/_pattern/text/__init__.py
@@ -239,7 +239,7 @@ def _read(path, encoding="utf-8", comment=";;;"):
             if not line or (comment and line.startswith(comment)):
                 continue
             yield line
-    raise StopIteration
+    return
 
 class Lexicon(lazydict):
 


### PR DESCRIPTION
Python 3.7 enabled [PEP 479](https://www.python.org/dev/peps/pep-0479/) which requires rewriting generator functions to not use `StopIteration`. I tested this fork with Python 2.7, 3.6, and 3.7. 

Also Google Translate returned subtly different translations ("Das" is "That" rather than "This") so I updated the tests to match.